### PR TITLE
Made user FFB stuff accessible to BP, allowing BP-implementated effects

### DIFF
--- a/Source/JoystickPlugin/Private/ForcedFeedback/ForcedFeedbackEffect.cpp
+++ b/Source/JoystickPlugin/Private/ForcedFeedback/ForcedFeedbackEffect.cpp
@@ -92,7 +92,7 @@ int32 UForcedFeedbackEffect::EffectStatus()
 	return result;
 }
 
-void UForcedFeedbackEffect::StartEffect()
+void UForcedFeedbackEffect::StartEffect_Implementation()
 {
 	SDL_Haptic* haptic = SDLFunctions::GetSDLHapticFromDeviceId(DeviceId);
 	if (haptic == nullptr)
@@ -129,7 +129,7 @@ void UForcedFeedbackEffect::StopEffect()
 	SDL_HapticStopEffect(haptic, EffectId);
 }
 
-void UForcedFeedbackEffect::UpdateEffect()
+void UForcedFeedbackEffect::UpdateEffect_Implementation()
 {
 	FForcedFeedbackData data = GetEffect();
 

--- a/Source/JoystickPlugin/Public/ForcedFeedback/ForcedFeedbackEffect.h
+++ b/Source/JoystickPlugin/Public/ForcedFeedback/ForcedFeedbackEffect.h
@@ -11,7 +11,7 @@ THIRD_PARTY_INCLUDES_END
 
 #include "ForcedFeedbackEffect.generated.h"
 
-UCLASS()
+UCLASS(Blueprintable)
 class UForcedFeedbackEffect : public UObject
 {
     GENERATED_BODY()
@@ -30,7 +30,7 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure)
 		int32 EffectStatus();
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable)
 		void StartEffect();
 
     UFUNCTION(BlueprintCallable)
@@ -39,7 +39,7 @@ public:
 	UFUNCTION(BlueprintCallable)
 		void DestroyEffect();
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable)
 		void UpdateEffect();
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Effect Configuration")
@@ -68,9 +68,10 @@ public:
 
 	virtual SDL_HapticEffect ToSDLEffect();
 
-private:
-	UPROPERTY(EditAnywhere)
+protected:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Effect Configuration")
 		FForcedFeedbackData EffectData;
 
+private:
     UWorld* GetWorld() const;
 };


### PR DESCRIPTION
Hey Jayden,

I've got your `develop` branch working on my end. I've re-implemented my FFB in your new object structure. Since my implementation was BP only, I needed some changes in the `UForcedFeedbackEffect` to make more things accessible in BP, so here's a PR with that.

I also had to add the lib+dll, but we're already discussing that in #9 so no PR for it.

Also, your classes are all named Force*d*Feedback, when it should be ForceFeedback. It's just in case you missed it, but don't feel obliged to change it, I know the pain of renaming classes in C++.