### PR TITLE
feat: :sparkles: add DeadZonePercentage parameter for binding detection

### DIFF
--- a/Source/JoystickPlugin/Public/Widgets/JoystickInputSelector.cpp
+++ b/Source/JoystickPlugin/Public/Widgets/JoystickInputSelector.cpp
@@ -47,6 +47,7 @@ UJoystickInputSelector::UJoystickInputSelector(const FObjectInitializer& ObjectI
 	bAllowGamepadKeys = true;
 	MinRangeOffset = 0.0f;
 	MaxRangeOffset = 0.0f;
+	DeadZone = 0.0f;
 	AxisSelectionTimeout = 2.5f;
 
 	EscapeKeys.AddUnique(EKeys::Gamepad_Special_Right);
@@ -177,6 +178,16 @@ void UJoystickInputSelector::SetAxisSelectionTimeout(float InAxisSelectionTimeou
 	AxisSelectionTimeout = InAxisSelectionTimeout;
 }
 
+void UJoystickInputSelector::SetDeadZone(float InDeadZone)
+{
+	if (JoystickInputSelector.IsValid())
+	{
+		JoystickInputSelector->SetDeadZone(InDeadZone);
+	}
+
+	DeadZone = InDeadZone;
+}
+
 bool UJoystickInputSelector::GetIsSelectingKey() const
 {
 	return JoystickInputSelector.IsValid() ? JoystickInputSelector->GetIsSelectingKey() : false;
@@ -223,6 +234,7 @@ void UJoystickInputSelector::SynchronizeProperties()
 	JoystickInputSelector->SetMinRangeOffset(MinRangeOffset);
 	JoystickInputSelector->SetMaxRangeOffset(MaxRangeOffset);
 	JoystickInputSelector->SetAxisSelectionTimeout(AxisSelectionTimeout);
+	JoystickInputSelector->SetDeadZone(DeadZone);
 	JoystickInputSelector->SetEscapeKeys(EscapeKeys);
 }
 
@@ -249,6 +261,7 @@ TSharedRef<SWidget> UJoystickInputSelector::RebuildWidget()
 		.SetMinRangeOffset(MinRangeOffset)
 		.SetMaxRangeOffset(MaxRangeOffset)
 		.SetAxisSelectionTimeout(AxisSelectionTimeout)
+		.SetDeadZone(DeadZone)
 		.EscapeKeys(EscapeKeys)
 		.OnAxisSelected(BIND_UOBJECT_DELEGATE(SJoystickInputSelector::FOnKeySelected, HandleAxisSelected))
 		.OnKeySelected(BIND_UOBJECT_DELEGATE(SJoystickInputSelector::FOnKeySelected, HandleKeySelected))

--- a/Source/JoystickPlugin/Public/Widgets/JoystickInputSelector.h
+++ b/Source/JoystickPlugin/Public/Widgets/JoystickInputSelector.h
@@ -87,6 +87,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Key Selection")
 	float AxisSelectionTimeout;
 
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Key Selection")
+	float DeadZone;
+
 	/** When true gamepad keys are allowed in the input chord representing the selected key, otherwise they are ignored. */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Key Selection")
 	TArray<FKey> EscapeKeys;
@@ -137,6 +140,9 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "Widget")
 	void SetAxisSelectionTimeout(float InAxisSelectionTimeout);
+
+	UFUNCTION(BlueprintCallable, Category = "Widget")
+	void SetDeadZone(float InDeadZone);
 
 	/** Returns true if the widget is currently selecting a key, otherwise returns false. */
 	UFUNCTION(BlueprintCallable, Category = "Widget")

--- a/Source/JoystickPlugin/Public/Widgets/SJoystickInputSelector.cpp
+++ b/Source/JoystickPlugin/Public/Widgets/SJoystickInputSelector.cpp
@@ -12,6 +12,7 @@ SJoystickInputSelector::SJoystickInputSelector()
 	  , MinRangeOffset(0.0f)
 	  , MaxRangeOffset(0.0f)
 	  , AxisSelectionTimeout(2.5f)
+	  , DeadZone(0.0f)
 	  , bAllowAxisKeys(true)
 	  , bAllowButtonKeys(true)
 	  , bAllowModifierKeys(true)
@@ -83,6 +84,14 @@ FReply SJoystickInputSelector::OnKeyUp(const FGeometry& MyGeometry, const FKeyEv
 
 FReply SJoystickInputSelector::OnAnalogValueChanged(const FGeometry& MyGeometry, const FAnalogInputEvent& InAnalogInputEvent)
 {
+	/** Don't process events in dead zone */
+	const float AbsAnalogValue = FMath::Abs(InAnalogInputEvent.GetAnalogValue());
+
+	if (AbsAnalogValue <= DeadZone)
+	{
+		return FReply::Handled();
+	}
+	
 	if (!bAllowAxisKeys)
 	{
 		return SCompoundWidget::OnAnalogValueChanged(MyGeometry, InAnalogInputEvent);

--- a/Source/JoystickPlugin/Public/Widgets/SJoystickInputSelector.h
+++ b/Source/JoystickPlugin/Public/Widgets/SJoystickInputSelector.h
@@ -40,6 +40,7 @@ public:
 			  , _SetMinRangeOffset(0.0f)
 			  , _SetMaxRangeOffset(0.0f)
 			  , _SetAxisSelectionTimeout(2.5f)
+			  , _SetDeadZone(0.0f)
 			  , _EscapeCancelsSelection(true)
 			  , _IsFocusable(true)
 		{
@@ -78,6 +79,8 @@ public:
 		SLATE_ARGUMENT(float, SetMinRangeOffset)
 		SLATE_ARGUMENT(float, SetMaxRangeOffset)
 		SLATE_ARGUMENT(float, SetAxisSelectionTimeout)
+
+		SLATE_ARGUMENT(float, SetDeadZone)
 
 		/** When true, pressing escape will cancel the key selection, when false, pressing escape will select the escape key. */
 		SLATE_ARGUMENT(bool, EscapeCancelsSelection)
@@ -125,6 +128,8 @@ public:
 	void SetMinRangeOffset(const float InMinRangeOffset) { MinRangeOffset = InMinRangeOffset; }
 	void SetMaxRangeOffset(const float InMaxRangeOffset) { MaxRangeOffset = InMaxRangeOffset; }
 	void SetAxisSelectionTimeout(const float InAxisSelectionTimeout) { AxisSelectionTimeout = InAxisSelectionTimeout; }
+
+	void SetDeadZone(const float InDeadZone) { DeadZone = InDeadZone; }
 
 	void SetAllowAxisKeys(const bool bInAllowAxisKeys) { bAllowAxisKeys = bInAllowAxisKeys; }
 	void SetAllowButtonKeys(const bool bInAllowButtonKeys) { bAllowButtonKeys = bInAllowButtonKeys; }
@@ -196,6 +201,9 @@ private:
 	float AxisSelectionTimeout;
 	TMap<FInputChord, FKeySelectorData> KeyData;
 
+	/** Define dead zone percentage to avoid unintentional axis mapping */
+	float DeadZone;
+	
 	bool bAllowAxisKeys;
 	bool bAllowButtonKeys;
 


### PR DESCRIPTION
I had problems with binding using JoystickInputSelector as some of my peripheral have jittering axis.
I added a new **Dead Zone Percentage** parameter to the widget, to disable detection on exterme values.

- -1 (+percentage)
- 0 (+ / - percentage)
- 1 (- percentage)
