### PR TITLE
fix: :bug: lingering data for disconnected devices

### DIFF
--- a/Source/JoystickPlugin/Private/ForceFeedback/JoystickForceFeedbackComponent.cpp
+++ b/Source/JoystickPlugin/Private/ForceFeedback/JoystickForceFeedbackComponent.cpp
@@ -11,6 +11,7 @@
 UJoystickForceFeedbackComponent::UJoystickForceFeedbackComponent(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	  , InstanceId(-1)
+	  , Tickable(true)
 {
 	bAutoActivate = true;
 	PrimaryComponentTick.bCanEverTick = true;
@@ -83,6 +84,13 @@ void UJoystickForceFeedbackComponent::TickComponent(const float DeltaTime, const
 	TickEffects(DeltaTime);
 }
 
+void UJoystickForceFeedbackComponent::SetComponentTickEnabled(const bool bEnabled)
+{
+	Super::SetComponentTickEnabled(bEnabled);
+
+	Running = bEnabled;
+}
+
 #if (ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3)
 void UJoystickForceFeedbackComponent::AsyncPhysicsTickComponent(const float DeltaTime, const float SimTime)
 {
@@ -97,8 +105,54 @@ void UJoystickForceFeedbackComponent::AsyncPhysicsTickComponent(const float Delt
 }
 #endif
 
+
+void UJoystickForceFeedbackComponent::SetTickable(const bool bTickable)
+{
+	Tickable = bTickable;
+	if (Running)
+	{
+		if (Tickable)
+		{
+			ActionOnAllEffects([](UForceFeedbackEffectBase* Effect)
+			{
+				Effect->StartEffect();
+			});
+		}
+		else
+		{
+			ActionOnAllEffects([](UForceFeedbackEffectBase* Effect)
+			{
+				Effect->StopEffect();
+			});
+		}
+	}
+}
+
+void UJoystickForceFeedbackComponent::OnSubsystemReady()
+{
+	CreateEffects();
+
+	if (!IsValid(GEngine))
+	{
+		return;
+	}
+
+	UJoystickSubsystem* JoystickSubsystem = GEngine->GetEngineSubsystem<UJoystickSubsystem>();
+	if (!IsValid(JoystickSubsystem))
+	{
+		return;
+	}
+
+	JoystickSubsystem->JoystickSubsystemReady.RemoveDynamic(this, &UJoystickForceFeedbackComponent::OnSubsystemReady);
+}
+
 void UJoystickForceFeedbackComponent::TickEffects(const float DeltaTime)
 {
+	if (!Running || !Tickable)
+	{
+		return;
+	}
+
 	if (!Configuration.OverrideEffectTick)
 	{
 		return;
@@ -124,24 +178,6 @@ void UJoystickForceFeedbackComponent::TickEffects(const float DeltaTime)
 
 		ForcedFeedbackEffect->Tick(DeltaTime);
 	}
-}
-
-void UJoystickForceFeedbackComponent::OnSubsystemReady()
-{
-	CreateEffects();
-
-	if (!IsValid(GEngine))
-	{
-		return;
-	}
-
-	UJoystickSubsystem* JoystickSubsystem = GEngine->GetEngineSubsystem<UJoystickSubsystem>();
-	if (!IsValid(JoystickSubsystem))
-	{
-		return;
-	}
-
-	JoystickSubsystem->JoystickSubsystemReady.RemoveDynamic(this, &UJoystickForceFeedbackComponent::OnSubsystemReady);
 }
 
 void UJoystickForceFeedbackComponent::CreateEffects()
@@ -297,6 +333,7 @@ TArray<UForceFeedbackEffectBase*> UJoystickForceFeedbackComponent::GetEffects() 
 
 void UJoystickForceFeedbackComponent::StartEffect()
 {
+	Running = true;
 	ActionOnAllEffects([](UForceFeedbackEffectBase* Effect)
 	{
 		Effect->StartEffect();
@@ -305,6 +342,7 @@ void UJoystickForceFeedbackComponent::StartEffect()
 
 void UJoystickForceFeedbackComponent::StopEffect()
 {
+	Running = false;
 	ActionOnAllEffects([](UForceFeedbackEffectBase* Effect)
 	{
 		Effect->StopEffect();

--- a/Source/JoystickPlugin/Private/JoystickInputDevice.cpp
+++ b/Source/JoystickPlugin/Private/JoystickInputDevice.cpp
@@ -128,7 +128,7 @@ void FJoystickInputDevice::InitialiseAxis(const FJoystickInstanceId& InstanceId,
 		}
 
 		const FKey AxisKey = FKey(FName(*AxisKeyName));
-		TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(AxisKey);
+		const TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(AxisKey);
 		if (!ExistingKeyDetails)
 		{
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 26 || ENGINE_MAJOR_VERSION == 5)
@@ -179,7 +179,7 @@ void FJoystickInputDevice::InitialiseButtons(const FJoystickInstanceId& Instance
 		}
 
 		const FKey ButtonKey = FKey(FName(*ButtonKeyName));
-		TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(ButtonKey);
+		const TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(ButtonKey);
 		if (!ExistingKeyDetails)
 		{
 			FKeyDetails ButtonKeyDetails = FKeyDetails(ButtonKey, FText::FromString(ButtonDisplayName), FKeyDetails::GamepadKey, JoystickCategory);
@@ -231,7 +231,7 @@ void FJoystickInputDevice::InitialiseHatAxis(const FJoystickInstanceId& Instance
 			FString HatDisplayName = FString::Printf(TEXT("%s: Hat %d %s"), *BaseDisplayName, HatKeyIndexName, *HatAxisName);
 
 			const FKey HatKey = FKey(FName(*HatKeyName));
-			TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(HatKey);
+			const TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(HatKey);
 			if (!ExistingKeyDetails)
 			{
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 26 || ENGINE_MAJOR_VERSION == 5)
@@ -255,7 +255,7 @@ void FJoystickInputDevice::InitialiseHatAxis(const FJoystickInstanceId& Instance
 			FString HatAxisDisplayName = FString::Printf(TEXT("%s: Hat %d 2D"), *BaseDisplayName, HatKeyIndexName);
 
 			const FKey HatAxisKey = FKey(FName(*HatAxisKeyName));
-			TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(HatAxisKey);
+			const TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(HatAxisKey);
 			if (!ExistingKeyDetails)
 			{
 				FKeyDetails HatAxisKeyDetails = FKeyDetails(HatAxisKey, FText::FromString(HatAxisDisplayName), FKeyDetails::GamepadKey | FKeyDetails::Axis2D, JoystickCategory);
@@ -309,7 +309,7 @@ void FJoystickInputDevice::InitialiseHatButtons(const FJoystickInstanceId& Insta
 			FString ButtonDisplayName = FString::Printf(TEXT("%s: Hat %d Button %s"), *BaseDisplayName, HatKeyIndexName, *DirectionDisplayName);
 
 			const FKey ButtonKey = FKey(FName(ButtonKeyName));
-			TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(ButtonKey);
+			const TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(ButtonKey);
 			if (!ExistingKeyDetails)
 			{
 				FKeyDetails ButtonKeyDetails = FKeyDetails(ButtonKey, FText::FromString(ButtonDisplayName), FKeyDetails::GamepadKey, JoystickCategory);
@@ -361,7 +361,7 @@ void FJoystickInputDevice::InitialiseBalls(const FJoystickInstanceId& InstanceId
 			FString BallDisplayName = FString::Printf(TEXT("%s: Ball %d %s"), *BaseDisplayName, BallKeyIndexName, *BallAxisName);
 
 			const FKey BallKey = FKey(FName(*BallKeyName));
-			TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(BallKey);
+			const TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(BallKey);
 			if (!ExistingKeyDetails)
 			{
 #if (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 26 || ENGINE_MAJOR_VERSION == 5)
@@ -385,7 +385,7 @@ void FJoystickInputDevice::InitialiseBalls(const FJoystickInstanceId& InstanceId
 			FString BallDisplayName = FString::Printf(TEXT("%s: Ball %d 2D"), *BaseDisplayName, BallKeyIndexName);
 
 			const FKey BallKey = FKey(FName(*BallKeyName));
-			TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(BallKey);
+			const TSharedPtr<FKeyDetails> ExistingKeyDetails = EKeys::GetKeyDetails(BallKey);
 			if (!ExistingKeyDetails)
 			{
 				FKeyDetails BallKeyDetails = FKeyDetails(BallKey, FText::FromString(BallDisplayName), FKeyDetails::GamepadKey | FKeyDetails::Axis2D, JoystickCategory);
@@ -488,7 +488,7 @@ void FJoystickInputDevice::JoystickPluggedIn(const FDeviceInfoSDL& Device)
 	FJoystickLogManager::Get()->LogInformation(TEXT("Device Ready: %s (Device Id: %d) - Instance Id: %d"), *Device.DeviceName, Device.GetInputDeviceId().GetId(), Device.InstanceId.Value);
 }
 
-void FJoystickInputDevice::JoystickUnplugged(const FJoystickInstanceId& InstanceId, const FInputDeviceId& InputDeviceId) const
+void FJoystickInputDevice::JoystickUnplugged(const FJoystickInstanceId& InstanceId, const FInputDeviceId& InputDeviceId)
 {
 	UJoystickInputSettings* JoystickInputSettings = GetMutableDefault<UJoystickInputSettings>();
 	if (!IsValid(JoystickInputSettings))
@@ -507,6 +507,20 @@ void FJoystickInputDevice::JoystickUnplugged(const FJoystickInstanceId& Instance
 		NotifyDeviceState(InputDeviceId, NewUserToAssign, EInputDeviceConnectionState::Disconnected);
 	}
 #endif
+
+	RemoveDeviceKeys(InstanceId);
+}
+
+void FJoystickInputDevice::RemoveDeviceKeys(const FJoystickInstanceId& InstanceId)
+{
+	DeviceButtonKeys.Remove(InstanceId);
+	DeviceAxisKeys.Remove(InstanceId);
+	DeviceHatAxisKeys.Remove(InstanceId);
+	DeviceHatAxisPairedKeys.Remove(InstanceId);
+	DeviceHatButtonKeys.Remove(InstanceId);
+	DeviceBallKeys.Remove(InstanceId);
+	DeviceBallPairedKeys.Remove(InstanceId);
+	DeviceKeys.Remove(InstanceId);
 }
 
 void FJoystickInputDevice::JoystickButton(const FJoystickInstanceId& InstanceId, const int Button, const bool Pressed)
@@ -676,7 +690,8 @@ void FJoystickInputDevice::SendControllerEvents()
 			continue;
 		}
 
-		FInputDeviceScope InputScope(this, JoystickInputInterfaceName, InstanceId, DeviceInfo.DeviceName);
+		const FString HardwareDeviceIdentifier = JoystickInputSettings->UseDeviceNameAsHardwareDeviceIdentifier ? DeviceInfo.DeviceName : "Joystick";
+		FInputDeviceScope InputScope(this, JoystickInputInterfaceName, InstanceId, HardwareDeviceIdentifier);
 
 		// Axis
 		if (DeviceAxisKeys.Contains(InstanceId))

--- a/Source/JoystickPlugin/Private/JoystickInputSettings.cpp
+++ b/Source/JoystickPlugin/Private/JoystickInputSettings.cpp
@@ -14,6 +14,10 @@
 UJoystickInputSettings::UJoystickInputSettings() : UseDeviceName(true),
                                                    IncludeDeviceIndex(false),
                                                    IgnoreGameControllers(false),
+                                                   AllowDuplicateHashedDevices(true),
+                                                   PrioritiseCollectionIndex(false),
+                                                   PrioritisationMethod(EJoystickPrioritisationType::Lowest),
+                                                   UseDeviceNameAsHardwareDeviceIdentifier(false),
                                                    ZeroBasedIndexing(true),
                                                    EnableLogs(true),
                                                    EnablePairedKeys(false)
@@ -50,9 +54,9 @@ bool UJoystickInputSettings::GetIgnoreGameControllers() const
 
 bool UJoystickInputSettings::SetIgnoreGameControllers(const bool NewIgnoreGameControllers)
 {
-	const bool OldIgnoreGameControllers = IgnoreGameControllers;
+	const bool Changed = IgnoreGameControllers != NewIgnoreGameControllers;
 	IgnoreGameControllers = NewIgnoreGameControllers;
-	return OldIgnoreGameControllers != NewIgnoreGameControllers;
+	return Changed;
 }
 
 FJoystickInputDeviceConfiguration* UJoystickInputSettings::GetDeviceConfiguration(const FJoystickInformation& Device)

--- a/Source/JoystickPlugin/Private/JoystickSubsystem.cpp
+++ b/Source/JoystickPlugin/Private/JoystickSubsystem.cpp
@@ -140,6 +140,58 @@ int UJoystickSubsystem::GetConnectedJoystickCount() const
 	return Count;
 }
 
+float UJoystickSubsystem::GetAxisKeyValue(const FKey& Key) const
+{
+	const FJoystickInputDevice* InputDevice = GetInputDevice();
+	if (InputDevice == nullptr)
+	{
+		return false;
+	}
+
+	const FJoystickInstanceId InstanceId = InputDevice->GetInstanceIdByKey(Key);
+	const int AxisIndex = InputDevice->GetAxisIndexFromKey(Key);
+
+	FJoystickDeviceState JoystickState;
+	const bool Result = GetJoystickState(InstanceId, JoystickState);
+	if (Result == false)
+	{
+		return 0.0f;
+	}
+
+	if (!JoystickState.Axes.IsValidIndex(AxisIndex))
+	{
+		return 0.0f;
+	}
+
+	return JoystickState.Axes[AxisIndex].GetValue();
+}
+
+float UJoystickSubsystem::GetAxisKeyMockValue(const FKey& Key, const FJoystickInputDeviceAxisProperties& AxisProperties) const
+{
+	const FJoystickInputDevice* InputDevice = GetInputDevice();
+	if (InputDevice == nullptr)
+	{
+		return false;
+	}
+
+	const FJoystickInstanceId InstanceId = InputDevice->GetInstanceIdByKey(Key);
+	const int AxisIndex = InputDevice->GetAxisIndexFromKey(Key);
+
+	FJoystickDeviceState JoystickState;
+	const bool Result = GetJoystickState(InstanceId, JoystickState);
+	if (Result == false)
+	{
+		return 0.0f;
+	}
+
+	if (!JoystickState.Axes.IsValidIndex(AxisIndex))
+	{
+		return 0.0f;
+	}
+
+	return JoystickState.Axes[AxisIndex].GetMockValue(AxisProperties);
+}
+
 bool UJoystickSubsystem::GetJoystickState(const FJoystickInstanceId& InstanceId, FJoystickDeviceState& JoystickDeviceState) const
 {
 	FJoystickInputDevice* InputDevice = GetInputDevice();
@@ -248,7 +300,7 @@ void UJoystickSubsystem::SetIgnoreGameControllers(const bool IgnoreControllers)
 				continue;
 			}
 
-			AddDevice(DeviceIndex);
+			AddDeviceByIndex(DeviceIndex);
 		}
 	}
 }
@@ -498,7 +550,7 @@ int UJoystickSubsystem::HandleSDLEvent(void* UserData, SDL_Event* Event)
 	{
 	case SDL_JOYDEVICEADDED:
 		{
-			JoystickSubsystem.AddDevice(Event->jdevice.which);
+			JoystickSubsystem.AddDeviceByIndex(Event->jdevice.which);
 			break;
 		}
 	case SDL_JOYDEVICEREMOVED:
@@ -553,7 +605,19 @@ int UJoystickSubsystem::HandleSDLEvent(void* UserData, SDL_Event* Event)
 	return 0;
 }
 
-bool UJoystickSubsystem::AddDevice(const int DeviceIndex)
+bool UJoystickSubsystem::AddDeviceByIndex(const int DeviceIndex)
+{
+	//TODO: Add collection index priority logic here somehow
+	FDeviceInfoSDL Device;
+	if (BuildDeviceInfoForIndex(DeviceIndex, Device))
+	{
+		return AddDevice(Device);
+	}
+
+	return false;
+}
+
+bool UJoystickSubsystem::AddDevice(FDeviceInfoSDL& Device)
 {
 	const UJoystickInputSettings* JoystickInputSettings = GetDefault<UJoystickInputSettings>();
 	if (!IsValid(JoystickInputSettings))
@@ -561,34 +625,23 @@ bool UJoystickSubsystem::AddDevice(const int DeviceIndex)
 		return false;
 	}
 
-	const bool IsGameController = SDL_IsGameController(DeviceIndex) == SDL_TRUE;
-	if (IsGameController && JoystickInputSettings->GetIgnoreGameControllers())
+	if (Device.IsGameController && JoystickInputSettings->GetIgnoreGameControllers())
 	{
 		// Let UE handle it
 		return false;
 	}
 
-	FDeviceInfoSDL Device;
-	Device.IsGameController = IsGameController;
 	Device.Connected = true;
-	Device.InstanceId = SDL_JoystickGetDeviceInstanceID(DeviceIndex);
-	Device.VendorId = SDL_JoystickGetDeviceVendor(DeviceIndex);
-	Device.ProductId = SDL_JoystickGetDeviceProduct(DeviceIndex);
-	Device.ProductVersion = SDL_JoystickGetDeviceProductVersion(DeviceIndex);
-
-	const SDL_JoystickGUID SDLGuid = SDL_JoystickGetDeviceGUID(DeviceIndex);
-	ConvertSDLGuid(SDLGuid, Device.ProductGuid);
-
-	Device.SDLJoystick = SDL_JoystickOpen(DeviceIndex);
+	Device.SDLJoystick = SDL_JoystickOpen(Device.DeviceIndex);
 	if (Device.SDLJoystick == nullptr)
 	{
 		FJoystickLogManager::Get()->LogSDLError(FString::Printf(TEXT("SDL_JoystickOpen failed for %d"), Device.InstanceId.Value));
 		return false;
 	}
 
-	if (IsGameController)
+	if (Device.IsGameController)
 	{
-		Device.SDLGameController = SDL_GameControllerOpen(DeviceIndex);
+		Device.SDLGameController = SDL_GameControllerOpen(Device.DeviceIndex);
 		if (Device.SDLGameController)
 		{
 			AddSensorDevice(Device);
@@ -614,10 +667,21 @@ bool UJoystickSubsystem::AddDevice(const int DeviceIndex)
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	Device.FirmwareVersion = SDL_JoystickGetFirmwareVersion(Device.SDLJoystick);
-	Device.Path = UJoystickFunctionLibrary::SafelyStringify(SDL_JoystickPath(Device.SDLJoystick));
 #endif
 
 	Device.DeviceHash = GenerateDeviceHash(Device);
+
+	if (JoystickInputSettings->AllowDuplicateHashedDevices == false)
+	{
+		for (TTuple<FJoystickInstanceId, FDeviceInfoSDL>& ExistingDevice : Devices)
+		{
+			if (ExistingDevice.Value.Connected && Device.DeviceHash == ExistingDevice.Value.DeviceHash)
+			{
+				CloseDeviceHandles(Device);
+				return false;
+			}
+		}
+	}
 
 	if (SDL_JoystickIsHaptic(Device.SDLJoystick))
 	{
@@ -626,7 +690,7 @@ bool UJoystickSubsystem::AddDevice(const int DeviceIndex)
 
 	FJoystickLogManager::Get()->LogDebug(TEXT("%s:"), *Device.DeviceName);
 	FJoystickLogManager::Get()->LogDebug(TEXT("\tInstance Id: %d"), Device.InstanceId.Value);
-	FJoystickLogManager::Get()->LogDebug(TEXT("\tSDL Device Index: %d"), DeviceIndex);
+	FJoystickLogManager::Get()->LogDebug(TEXT("\tSDL Device Index: %d"), Device.DeviceIndex);
 	FJoystickLogManager::Get()->LogDebug(TEXT("\tProduct Id: %d"), Device.ProductId);
 	FJoystickLogManager::Get()->LogDebug(TEXT("\tProduct Guid: %s"), *Device.ProductGuid.ToString());
 	FJoystickLogManager::Get()->LogDebug(TEXT("\tProduct Version: %d"), Device.ProductVersion);
@@ -763,25 +827,7 @@ bool UJoystickSubsystem::RemoveDevice(const FJoystickInstanceId& InstanceId)
 	}
 
 	JoystickUnplugged(InstanceId, DeviceInfo->GetInputDeviceId());
-
-	if (DeviceInfo->SDLHaptic != nullptr)
-	{
-		FJoystickLogManager::Get()->LogDebug(TEXT("Closing haptic for device %d"), InstanceId.Value);
-		SDL_HapticClose(DeviceInfo->SDLHaptic);
-		DeviceInfo->SDLHaptic = nullptr;
-	}
-	if (DeviceInfo->SDLJoystick != nullptr)
-	{
-		FJoystickLogManager::Get()->LogDebug(TEXT("Closing joystick for device %d"), InstanceId.Value);
-		SDL_JoystickClose(DeviceInfo->SDLJoystick);
-		DeviceInfo->SDLJoystick = nullptr;
-	}
-	if (DeviceInfo->SDLGameController != nullptr)
-	{
-		FJoystickLogManager::Get()->LogDebug(TEXT("Closing game controller for device %d"), InstanceId.Value);
-		SDL_GameControllerClose(DeviceInfo->SDLGameController);
-		DeviceInfo->SDLGameController = nullptr;
-	}
+	CloseDeviceHandles(*DeviceInfo);
 
 	DeviceInfo->Connected = false;
 	FJoystickLogManager::Get()->LogInformation(TEXT("Device removed: %d"), InstanceId.Value);
@@ -798,6 +844,28 @@ bool UJoystickSubsystem::RemoveDeviceByIndex(const int DeviceIndex)
 	}
 
 	return RemoveDevice(InstanceId);
+}
+
+void UJoystickSubsystem::CloseDeviceHandles(FDeviceInfoSDL& Device) const
+{
+	if (Device.SDLHaptic != nullptr)
+	{
+		FJoystickLogManager::Get()->LogDebug(TEXT("Closing haptic for device %d"), Device.InstanceId.Value);
+		SDL_HapticClose(Device.SDLHaptic);
+		Device.SDLHaptic = nullptr;
+	}
+	if (Device.SDLJoystick != nullptr)
+	{
+		FJoystickLogManager::Get()->LogDebug(TEXT("Closing joystick for device %d"), Device.InstanceId.Value);
+		SDL_JoystickClose(Device.SDLJoystick);
+		Device.SDLJoystick = nullptr;
+	}
+	if (Device.SDLGameController != nullptr)
+	{
+		FJoystickLogManager::Get()->LogDebug(TEXT("Closing game controller for device %d"), Device.InstanceId.Value);
+		SDL_GameControllerClose(Device.SDLGameController);
+		Device.SDLGameController = nullptr;
+	}
 }
 
 bool UJoystickSubsystem::FindExistingDevice(const FDeviceInfoSDL& Device, FJoystickInstanceId& PreviousJoystickInstanceId, FInputDeviceId& ExistingInputDeviceId, FPlatformUserId& ExistingPlatformUserId)
@@ -824,10 +892,58 @@ bool UJoystickSubsystem::FindExistingDevice(const FDeviceInfoSDL& Device, FJoyst
 
 void UJoystickSubsystem::InitialiseExistingJoysticks()
 {
-	const int JoystickCount = GetRawJoystickCount();
-	for (int i = 0; i < JoystickCount; i++)
+	const UJoystickInputSettings* JoystickInputSettings = GetDefault<UJoystickInputSettings>();
+	if (!IsValid(JoystickInputSettings))
 	{
-		AddDevice(i);
+		return;
+	}
+
+	TArray<FDeviceInfoSDL> DeviceInfos;
+	const int JoystickCount = GetRawJoystickCount();
+	for (int DeviceIndex = 0; DeviceIndex < JoystickCount; DeviceIndex++)
+	{
+		FDeviceInfoSDL Device;
+		if (BuildDeviceInfoForIndex(DeviceIndex, Device))
+		{
+			DeviceInfos.Add(Device);
+		}
+	}
+
+	for (FDeviceInfoSDL& Device : DeviceInfos)
+	{
+		if (JoystickInputSettings->PrioritiseCollectionIndex == false)
+		{
+			AddDevice(Device);
+			continue;
+		}
+
+		const FDeviceInfoSDL* ExistingDevice = DeviceInfos.FindByPredicate([&Device](const FDeviceInfoSDL& DeviceInfo)
+		{
+			return Device.InstanceId != DeviceInfo.InstanceId && Device.ProductGuid == DeviceInfo.ProductGuid; // Using GUID here as the hash cannot be properly generated without a serial number
+		});
+
+		if (ExistingDevice == nullptr || Device.CollectionIndex == -1)
+		{
+			AddDevice(Device);
+			continue;
+		}
+
+		bool HasCollectionPriority;
+		switch (JoystickInputSettings->PrioritisationMethod)
+		{
+		default:
+		case EJoystickPrioritisationType::Lowest:
+			HasCollectionPriority = Device.CollectionIndex < ExistingDevice->CollectionIndex;
+			break;
+		case EJoystickPrioritisationType::Highest:
+			HasCollectionPriority = Device.CollectionIndex > ExistingDevice->CollectionIndex;
+			break;
+		}
+
+		if (HasCollectionPriority)
+		{
+			AddDevice(Device);
+		}
 	}
 }
 
@@ -858,7 +974,7 @@ void UJoystickSubsystem::JoystickPluggedIn(const FDeviceInfoSDL& Device) const
 
 void UJoystickSubsystem::JoystickUnplugged(const FJoystickInstanceId& InstanceId, const FInputDeviceId& InputDeviceId) const
 {
-	const FJoystickInputDevice* InputDevice = GetInputDevice();
+	FJoystickInputDevice* InputDevice = GetInputDevice();
 	if (InputDevice == nullptr)
 	{
 		return;
@@ -894,6 +1010,40 @@ void UJoystickSubsystem::LoadGameControllerMappings() const
 	}
 }
 
+bool UJoystickSubsystem::BuildDeviceInfoForIndex(const int DeviceIndex, FDeviceInfoSDL& Device) const
+{
+	if (DeviceIndex < 0 || DeviceIndex >= GetRawJoystickCount())
+	{
+		return false;
+	}
+
+	Device = FDeviceInfoSDL();
+	Device.DeviceIndex = DeviceIndex;
+	Device.InstanceId = SDL_JoystickGetDeviceInstanceID(DeviceIndex);
+	if (Device.InstanceId == -1)
+	{
+		return false;
+	}
+
+	Device.IsGameController = SDL_IsGameController(DeviceIndex) == SDL_TRUE;
+	Device.VendorId = SDL_JoystickGetDeviceVendor(DeviceIndex);
+	Device.ProductId = SDL_JoystickGetDeviceProduct(DeviceIndex);
+	Device.ProductVersion = SDL_JoystickGetDeviceProductVersion(DeviceIndex);
+	Device.Type = static_cast<EJoystickType>(SDL_JoystickGetDeviceType(DeviceIndex));
+	Device.DeviceName = UJoystickFunctionLibrary::SafelyStringify(SDL_JoystickNameForIndex(DeviceIndex));
+	Device.SafeDeviceName = UJoystickFunctionLibrary::SanitiseDeviceName(Device.DeviceName);
+
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
+	Device.Path = UJoystickFunctionLibrary::SafelyStringify(SDL_JoystickPathForIndex(DeviceIndex));
+	Device.CollectionIndex = CollectionIndexFromPath(Device.Path);
+#endif
+
+	const SDL_JoystickGUID SDLGuid = SDL_JoystickGetDeviceGUID(DeviceIndex);
+	ConvertSDLGuid(SDLGuid, Device.ProductGuid);
+
+	return Device.InstanceId != -1;
+}
+
 void UJoystickSubsystem::ConvertSDLGuid(const SDL_JoystickGUID& SdlGuid, FGuid& OutGuid) const
 {
 	FMemory::Memcpy(&OutGuid.A, &SdlGuid.data[0], 4);
@@ -917,6 +1067,43 @@ FString UJoystickSubsystem::GenerateDeviceHash(const FDeviceInfoSDL& Device) con
 
 	const uint32 HashValue = GetTypeHash(FullSignature);
 	return FString::Printf(TEXT("%08X"), HashValue);
+}
+
+int UJoystickSubsystem::CollectionIndexFromPath(const FString& Path) const
+{
+#if PLATFORM_WINDOWS
+	const int32 GuidMarker = Path.Find(TEXT("#{"), ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+	if (GuidMarker == INDEX_NONE)
+	{
+		return -1;
+	}
+
+	const int32 LastAmpersand = Path.Left(GuidMarker).Find(
+		TEXT("&"),
+		ESearchCase::CaseSensitive,
+		ESearchDir::FromEnd
+	);
+
+	if (LastAmpersand == INDEX_NONE)
+	{
+		return -1;
+	}
+
+	const FString IndexString = Path.Mid(
+		LastAmpersand + 1,
+		GuidMarker - LastAmpersand - 1
+	);
+
+	if (!IndexString.IsNumeric())
+	{
+		return -1;
+	}
+
+	return FCString::Atoi(*IndexString);
+#else
+	//TODO: Other platform support
+	return -1;
+#endif
 }
 
 FString UJoystickSubsystem::GameControllerMappingFile("gamecontrollerdb.txt");

--- a/Source/JoystickPlugin/Private/Widgets/JoystickInputSelector.cpp
+++ b/Source/JoystickPlugin/Private/Widgets/JoystickInputSelector.cpp
@@ -309,11 +309,11 @@ void UJoystickInputSelector::SetTextBlockVisibility(const ESlateVisibility InVis
 	}
 }
 
-void UJoystickInputSelector::HandleIsSelectingChanged() const
+void UJoystickInputSelector::HandleIsSelectingChanged(const bool Selecting) const
 {
 	if (OnIsSelectingChanged.IsBound())
 	{
-		OnIsSelectingChanged.Broadcast();
+		OnIsSelectingChanged.Broadcast(Selecting);
 	}
 }
 

--- a/Source/JoystickPlugin/Private/Widgets/SJoystickInputSelector.cpp
+++ b/Source/JoystickPlugin/Private/Widgets/SJoystickInputSelector.cpp
@@ -69,11 +69,11 @@ void SJoystickInputSelector::SetMargin(const TAttribute<FMargin>& InMargin)
 	Margin = InMargin;
 }
 
-void SJoystickInputSelector::SetButtonStyle(const FButtonStyle* ButtonStyle) const
+void SJoystickInputSelector::SetButtonStyle(const FButtonStyle* InButtonStyle) const
 {
 	if (Button.IsValid())
 	{
-		Button->SetButtonStyle(ButtonStyle);
+		Button->SetButtonStyle(InButtonStyle);
 	}
 }
 
@@ -212,13 +212,13 @@ FReply SJoystickInputSelector::OnAnalogValueChanged(const FGeometry& MyGeometry,
 				{
 					SelectedKeyData.Reset();
 					SelectedKeyData.bWasSelecting = true;
-					SetIsSelectingKey(false);
 					SelectKey(
 						AxisKey,
 						ModifierKey == EModifierKey::Shift,
 						ModifierKey == EModifierKey::Control,
 						ModifierKey == EModifierKey::Alt,
 						ModifierKey == EModifierKey::Command);
+					SetIsSelectingKey(false);
 					return FReply::Handled();
 				}
 				break;
@@ -230,13 +230,13 @@ FReply SJoystickInputSelector::OnAnalogValueChanged(const FGeometry& MyGeometry,
 				{
 					SelectedKeyData.Reset();
 					SelectedKeyData.bWasSelecting = true;
-					SetIsSelectingKey(false);
 					SelectKey(
 						AxisKey,
 						ModifierKey == EModifierKey::Shift,
 						ModifierKey == EModifierKey::Control,
 						ModifierKey == EModifierKey::Alt,
 						ModifierKey == EModifierKey::Command);
+					SetIsSelectingKey(false);
 					return FReply::Handled();
 				}
 				break;
@@ -263,11 +263,6 @@ FReply SJoystickInputSelector::OnKeyDown(const FGeometry& MyGeometry, const FKey
 {
 	if (!bIsSelectingKey)
 	{
-		if (SelectedKey.IsSet() && SelectedKey.Get().Key.IsValid() && ShouldProcessInputKey(InKeyEvent.GetKey()))
-		{
-			SetSelectedKey(FInputChord());
-			return FReply::Handled();
-		}
 		if (Button.IsValid())
 		{
 			return Button->OnKeyDown(MyGeometry, InKeyEvent);
@@ -278,12 +273,6 @@ FReply SJoystickInputSelector::OnKeyDown(const FGeometry& MyGeometry, const FKey
 
 FReply SJoystickInputSelector::OnKeyUp(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent)
 {
-	const bool bAllowButtonKeys = (KeySelectorTypes & static_cast<int32>(EKeySelectorTypes::Button)) != 0;
-	if (!bAllowButtonKeys)
-	{
-		return SCompoundWidget::OnKeyUp(MyGeometry, InKeyEvent);
-	}
-
 	const FKey KeyUp = InKeyEvent.GetKey();
 	const EModifierKey::Type ModifierKey = EModifierKey::FromBools(
 		InKeyEvent.IsControlDown() && KeyUp != EKeys::LeftControl && KeyUp != EKeys::RightControl,
@@ -301,9 +290,9 @@ FReply SJoystickInputSelector::OnKeyUp(const FGeometry& MyGeometry, const FKeyEv
 		ShouldProcessInputKey(KeyUp) &&
 		!bShouldSkipModifierKey)
 	{
-		SetIsSelectingKey(false);
 		if (bEscapeCancelsSelection && (KeyUp == EKeys::Escape || IsEscapeKey(KeyUp)))
 		{
+			SetIsSelectingKey(false);
 			return FReply::Handled();
 		}
 
@@ -313,6 +302,7 @@ FReply SJoystickInputSelector::OnKeyUp(const FGeometry& MyGeometry, const FKeyEv
 			ModifierKey == EModifierKey::Control,
 			ModifierKey == EModifierKey::Alt,
 			ModifierKey == EModifierKey::Command);
+		SetIsSelectingKey(false);
 		return FReply::Handled();
 	}
 	if (!bIsSelectingKey && Button.IsValid())
@@ -325,6 +315,11 @@ FReply SJoystickInputSelector::OnKeyUp(const FGeometry& MyGeometry, const FKeyEv
 
 FReply SJoystickInputSelector::OnPreviewKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent)
 {
+	if (!bIsSelectingKey)
+	{
+		return FReply::Unhandled();
+	}
+
 	if (bIsSelectingKey && ShouldProcessInputKey(InKeyEvent.GetKey()))
 	{
 		// While selecting keys handle all key downs to prevent contained controls from
@@ -341,9 +336,13 @@ FReply SJoystickInputSelector::OnPreviewMouseButtonDown(const FGeometry& MyGeome
 		const FKey MouseButton = MouseEvent.GetEffectingButton();
 		if (ShouldProcessInputKey(MouseButton))
 		{
+			SelectKey(
+				MouseButton,
+				MouseEvent.IsShiftDown(),
+				MouseEvent.IsControlDown(),
+				MouseEvent.IsAltDown(),
+				MouseEvent.IsCommandDown());
 			SetIsSelectingKey(false);
-			// TODO: Add options for enabling mouse modifiers.
-			SelectKey(MouseButton, false, false, false, false);
 			return FReply::Handled();
 		}
 	}
@@ -434,7 +433,7 @@ void SJoystickInputSelector::SetIsSelectingKey(const bool bInIsSelectingKey)
 		{
 			Button->SetEnabled(!bIsSelectingKey);
 		}
-		OnIsSelectingChanged.ExecuteIfBound();
+		OnIsSelectingChanged.ExecuteIfBound(bIsSelectingKey);
 	}
 }
 
@@ -445,6 +444,16 @@ bool SJoystickInputSelector::IsEscapeKey(const FKey& InKey) const
 
 bool SJoystickInputSelector::ShouldProcessInputKey(const FKey& InKey) const
 {
+	if (!InKey.IsValid())
+	{
+		return false;
+	}
+
+	if (IsEscapeKey(InKey))
+	{
+		return true;
+	}
+
 	const bool bAllowKeyboardKeys = (InputSelectorTypes & static_cast<int32>(EInputSelectorTypes::Keyboard)) != 0;
 	const bool bAllowMouseKeys = (InputSelectorTypes & static_cast<int32>(EInputSelectorTypes::Mouse)) != 0;
 	const bool bAllowGamepadKeys = (InputSelectorTypes & static_cast<int32>(EInputSelectorTypes::Gamepad)) != 0;

--- a/Source/JoystickPlugin/Public/Data/DeviceInfoSDL.h
+++ b/Source/JoystickPlugin/Public/Data/DeviceInfoSDL.h
@@ -18,7 +18,8 @@ THIRD_PARTY_INCLUDES_END
 struct FDeviceInfoSDL : FJoystickInformation
 {
 	FDeviceInfoSDL()
-		: Connected(false)
+		: DeviceIndex(-1)
+		  , Connected(false)
 		  , SDLHaptic(nullptr)
 		  , SDLJoystick(nullptr)
 		  , SDLGameController(nullptr)
@@ -47,6 +48,7 @@ struct FDeviceInfoSDL : FJoystickInformation
 		return PlatformUserId;
 	}
 
+	int DeviceIndex;
 	bool Connected;
 	SDL_Haptic* SDLHaptic;
 	SDL_Joystick* SDLJoystick;

--- a/Source/JoystickPlugin/Public/Data/Input/AxisData.h
+++ b/Source/JoystickPlugin/Public/Data/Input/AxisData.h
@@ -39,8 +39,8 @@ struct JOYSTICKPLUGIN_API FAxisData
 		const float OffsetNormalizedValue = InvertedInput + AxisProperties.InputOffset;
 		if (AxisProperties.RerangeInput || AxisProperties.RerangeOutput)
 		{
-			const float MappedValue = FMath::GetMappedRangeValueClamped(FVector2D(InputRangeMin, InputRangeMax), FVector2D(OutputRangeMin, OutputRangeMax), OffsetNormalizedValue);
-			return InvertOutput ? -MappedValue : MappedValue;
+			const float MappedValue = FMath::GetMappedRangeValueClamped(FVector2D(AxisProperties.InputRangeMin, AxisProperties.InputRangeMax), FVector2D(AxisProperties.OutputRangeMin, AxisProperties.OutputRangeMax), OffsetNormalizedValue);
+			return AxisProperties.InvertOutput ? -MappedValue : MappedValue;
 		}
 		return AxisProperties.InvertOutput ? -OffsetNormalizedValue : OffsetNormalizedValue;
 	}

--- a/Source/JoystickPlugin/Public/Data/JoystickInformation.h
+++ b/Source/JoystickPlugin/Public/Data/JoystickInformation.h
@@ -28,6 +28,7 @@ struct FJoystickInformation
 		  , PowerLevel(EJoystickPowerLevel::Unknown)
 		  , LedSupport(false)
 		  , RumbleSupport(false)
+		  , CollectionIndex(-1)
 	{
 	}
 
@@ -90,4 +91,6 @@ struct FJoystickInformation
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Device Config|Sensors")
 	FJoystickSensorInformation Accelerometer;
+
+	int CollectionIndex;
 };

--- a/Source/JoystickPlugin/Public/Data/Settings/JoystickPrioritisationType.h
+++ b/Source/JoystickPlugin/Public/Data/Settings/JoystickPrioritisationType.h
@@ -1,0 +1,13 @@
+﻿// JoystickPlugin is licensed under the MIT License.
+// Copyright Jayden Maalouf 2026. All Rights Reserved.
+
+#pragma once
+
+#include "JoystickPrioritisationType.generated.h"
+
+UENUM(BlueprintType)
+enum class EJoystickPrioritisationType : uint8
+{
+	Lowest = 0,
+	Highest
+};

--- a/Source/JoystickPlugin/Public/ForceFeedback/JoystickForceFeedbackComponent.h
+++ b/Source/JoystickPlugin/Public/ForceFeedback/JoystickForceFeedbackComponent.h
@@ -23,10 +23,14 @@ public:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+	virtual void SetComponentTickEnabled(bool bEnabled) override;
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 	virtual void AsyncPhysicsTickComponent(float DeltaTime, float SimTime) override;
 #endif
+
+	UFUNCTION(BlueprintCallable)
+	void SetTickable(const bool bTickable);
 
 	UFUNCTION(BlueprintNativeEvent, Category="Joystick|Force Feedback Component|Events")
 	void OnInitialisedEffect(const UForceFeedbackEffectBase* Effect);
@@ -63,6 +67,12 @@ public:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Joystick|Force Feedback Component")
 	TArray<UForceFeedbackEffectBase*> Effects;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Joystick|Force Feedback Component")
+	bool Running;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Joystick|Force Feedback Component")
+	bool Tickable;
 
 private:
 	UFUNCTION()

--- a/Source/JoystickPlugin/Public/JoystickInputDevice.h
+++ b/Source/JoystickPlugin/Public/JoystickInputDevice.h
@@ -32,7 +32,7 @@ public:
 	virtual bool IsGamepadAttached() const override;
 
 	void JoystickPluggedIn(const FDeviceInfoSDL& Device);
-	void JoystickUnplugged(const FJoystickInstanceId& InstanceId, const FInputDeviceId& InputDeviceId) const;
+	void JoystickUnplugged(const FJoystickInstanceId& InstanceId, const FInputDeviceId& InputDeviceId);
 	void JoystickButton(const FJoystickInstanceId& InstanceId, const int Button, const bool Pressed);
 	void JoystickAxis(const FJoystickInstanceId& InstanceId, const int Axis, const float Value);
 	void JoystickHat(const FJoystickInstanceId& InstanceId, const int Hat, const EHatDirection Value);
@@ -61,6 +61,7 @@ private:
 	void InitialiseHatAxis(const FJoystickInstanceId& InstanceId, const FString& BaseKeyName, const FString& BaseDisplayName, const bool PairedKey);
 	void InitialiseHatButtons(const FJoystickInstanceId& InstanceId, const FString& BaseKeyName, const FString& BaseDisplayName);
 	void InitialiseBalls(const FJoystickInstanceId& InstanceId, const FString& BaseKeyName, const FString& BaseDisplayName, const bool PairedKey);
+	void RemoveDeviceKeys(const FJoystickInstanceId& InstanceId);
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 	void NotifyDeviceState(const FInputDeviceId& InputDeviceId, const FPlatformUserId& PlatformUserId, const EInputDeviceConnectionState State) const;
 #endif

--- a/Source/JoystickPlugin/Public/JoystickInputSettings.h
+++ b/Source/JoystickPlugin/Public/JoystickInputSettings.h
@@ -6,6 +6,7 @@
 #include "Data/JoystickInformation.h"
 #include "Data/Settings/JoystickInputKeyConfiguration.h"
 #include "InputCoreTypes.h"
+#include "Data/Settings/JoystickPrioritisationType.h"
 
 #include "JoystickInputSettings.generated.h"
 
@@ -30,7 +31,23 @@ public:
 	UPROPERTY(config, EditAnywhere, Category="Joystick Settings", meta=(ToolTip="Useful if you want input for controllers (ie. XInput) to be handled by UE directly, instead of via this plugin.", ConfigRestartRequired=true))
 	bool IgnoreGameControllers;
 
-	UPROPERTY(config, EditAnywhere, Category="Joystick Settings", meta=(ToolTip="Key name indexes should start from 0 (if false, starts from 1)", ConfigRestartRequired=true))
+	UPROPERTY(config, EditAnywhere, Category="Joystick Settings|Advanced", meta=(ToolTip="If false, will not add a Joystick if a mapped device with the same hash exists.", ConfigRestartRequired=true))
+	bool AllowDuplicateHashedDevices;
+
+	UPROPERTY(config, EditAnywhere, Category="Joystick Settings|Advanced", DisplayName="Prioritise Devices by Collection Index",
+		meta=(ToolTip="If true, will skip devices with the same GUID based on the driver collection index prioritisation method. Useful for drivers that map multiple devices for the same GUID.",
+			EditConditionHides, ConfigRestartRequired=true))
+	bool PrioritiseCollectionIndex;
+
+	UPROPERTY(config, EditAnywhere, Category="Joystick Settings|Advanced",
+		meta=(ToolTip="The prioritisation method to use.", EditCondition="PrioritiseCollectionIndex", ConfigRestartRequired=true))
+	EJoystickPrioritisationType PrioritisationMethod;
+
+	UPROPERTY(config, EditAnywhere, Category="Joystick Settings|Advanced",
+		meta=(ToolTip="Use the device name as the hardware device identifier. Useful if you need specific hardware identification (ie. for icons).", ConfigRestartRequired=true))
+	bool UseDeviceNameAsHardwareDeviceIdentifier;
+
+	UPROPERTY(config, EditAnywhere, Category="Joystick Settings|Advanced", meta=(ToolTip="Key name indexes should start from 0 (if false, starts from 1)", ConfigRestartRequired=true))
 	bool ZeroBasedIndexing;
 
 	UPROPERTY(config, EditAnywhere, Category="Joystick Settings|Debugging", meta=(ToolTip="Enable debug logging from the plugin."))

--- a/Source/JoystickPlugin/Public/JoystickSubsystem.h
+++ b/Source/JoystickPlugin/Public/JoystickSubsystem.h
@@ -62,6 +62,12 @@ public:
 	int GetConnectedJoystickCount() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintPure=false, Category="Joystick", meta=(ToolTip="The raw input state of the specified joystick."))
+	float GetAxisKeyValue(const FKey& Key) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintPure=false, Category="Joystick", meta=(ToolTip="The raw input state of the specified joystick."))
+	float GetAxisKeyMockValue(const FKey& Key, const FJoystickInputDeviceAxisProperties& AxisProperties) const;
+
+	UFUNCTION(BlueprintCallable, BlueprintPure=false, Category="Joystick", meta=(ToolTip="The raw input state of the specified joystick."))
 	bool GetJoystickState(const FJoystickInstanceId& InstanceId, FJoystickDeviceState& JoystickDeviceState) const;
 
 	UFUNCTION(BlueprintCallable, Category="Joystick")
@@ -129,12 +135,14 @@ public:
 
 private:
 	static int HandleSDLEvent(void* UserData, SDL_Event* Event);
+	bool AddDeviceByIndex(int DeviceIndex);
 
-	bool AddDevice(const int DeviceIndex);
+	bool AddDevice(FDeviceInfoSDL& Device);
 	void AddHapticDevice(FDeviceInfoSDL& Device) const;
 	void AddSensorDevice(FDeviceInfoSDL& Device) const;
 	bool RemoveDevice(const FJoystickInstanceId& InstanceId);
 	bool RemoveDeviceByIndex(const int DeviceIndex);
+	void CloseDeviceHandles(FDeviceInfoSDL& Device) const;
 
 	bool FindExistingDevice(const FDeviceInfoSDL& Device, FJoystickInstanceId& PreviousJoystickInstanceId, FInputDeviceId& ExistingInputDeviceId, FPlatformUserId& ExistingPlatformUserId);
 
@@ -145,8 +153,10 @@ private:
 
 	void LoadGameControllerMappings() const;
 
+	bool BuildDeviceInfoForIndex(const int DeviceIndex, FDeviceInfoSDL& Device) const;
 	void ConvertSDLGuid(const SDL_JoystickGUID& SdlGuid, FGuid& OutGuid) const;
 	FString GenerateDeviceHash(const FDeviceInfoSDL& Device) const;
+	int CollectionIndexFromPath(const FString& Path) const;
 
 	TMap<FJoystickInstanceId, FDeviceInfoSDL> Devices;
 

--- a/Source/JoystickPlugin/Public/Managers/JoystickProfileManager.h
+++ b/Source/JoystickPlugin/Public/Managers/JoystickProfileManager.h
@@ -11,7 +11,7 @@
 class UJoystickSubsystem;
 class FJoystickInputDevice;
 
-UCLASS(BlueprintType, DisplayName="Joystick HID Manager")
+UCLASS(BlueprintType, DisplayName="Joystick Profile Manager")
 class JOYSTICKPLUGIN_API UJoystickProfileManager : public UObject
 {
 	GENERATED_BODY()

--- a/Source/JoystickPlugin/Public/Widgets/JoystickInputSelector.h
+++ b/Source/JoystickPlugin/Public/Widgets/JoystickInputSelector.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
 #include "UObject/ObjectMacros.h"
 #include "Framework/Commands/InputChord.h"
 #include "Fonts/SlateFontInfo.h"
@@ -20,11 +21,11 @@ struct FButtonStyle;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnKeySelected, FInputChord, SelectedKey);
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnIsSelectingChanged);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnIsSelectingChanged, bool, Selecting);
 
 /** A widget for selecting a single key or a single key with a modifier. */
 UCLASS()
-class JOYSTICKPLUGIN_API UJoystickInputSelector : public UWidget
+class JOYSTICKPLUGIN_API UJoystickInputSelector : public UUserWidget
 {
 	GENERATED_BODY()
 
@@ -199,7 +200,7 @@ protected:
 
 private:
 	virtual void HandleKeySelected(const FInputChord& InSelectedKey);
-	void HandleIsSelectingChanged() const;
+	void HandleIsSelectingChanged(bool Selecting) const;
 
 	/** The input key selector widget managed by this object. */
 	TSharedPtr<SJoystickInputSelector> JoystickInputSelector;

--- a/Source/JoystickPlugin/Public/Widgets/SJoystickInputSelector.h
+++ b/Source/JoystickPlugin/Public/Widgets/SJoystickInputSelector.h
@@ -25,7 +25,7 @@ class JOYSTICKPLUGIN_API SJoystickInputSelector : public SCompoundWidget
 {
 public:
 	DECLARE_DELEGATE_OneParam(FOnKeySelected, const FInputChord&)
-	DECLARE_DELEGATE(FOnIsSelectingChanged)
+	DECLARE_DELEGATE_OneParam(FOnIsSelectingChanged, bool)
 
 	SLATE_BEGIN_ARGS(SJoystickInputSelector)
 			: _SelectedKey(FInputChord(EKeys::Invalid))
@@ -107,7 +107,7 @@ public:
 	void SetMargin(const TAttribute<FMargin>& InMargin);
 
 	/** Sets the style of the button which is used enter key selection mode. */
-	void SetButtonStyle(const FButtonStyle* ButtonStyle) const;
+	void SetButtonStyle(const FButtonStyle* InButtonStyle) const;
 
 	/** Sets the style of the text on the button which is used enter key selection mode. */
 	void SetTextStyle(const FTextBlockStyle* InTextStyle) const;

--- a/Source/JoystickPluginEditor/JoystickPluginEditor.Build.cs
+++ b/Source/JoystickPluginEditor/JoystickPluginEditor.Build.cs
@@ -15,7 +15,7 @@ public class JoystickPluginEditor : ModuleRules
 			"Slate",
 			"SlateCore",
 			"InputCore",
-			"JoystickPlugin", 
+			"JoystickPlugin",
 			"SettingsEditor"
 		});
 


### PR DESCRIPTION
:sparkles: added collection based prioritisation
:sparkles: added axis key value getting method
:sparkles: added start/stop to effect component
:bug: set selecting happening before set key
:sparkles: added selecting output to delegate
:sparkles: added ignore for dupllicate device guids
:bug: axis previewer was not updating on edits
:bug: profile manager name in blueprint